### PR TITLE
Fix get_running issue for jenkins slave

### DIFF
--- a/files/jenkins-slave.Debian
+++ b/files/jenkins-slave.Debian
@@ -92,7 +92,7 @@ do_start()
 # 
 get_running() 
 {
-    return `ps -U $JENKINS_SLAVE_USER --no-headers -f | egrep -e '(java|daemon)' | grep -c . `
+    return `ps -U $JENKINS_SLAVE_USER --no-headers | egrep -e '(java|daemon)' | grep -c . `
 }
 
 force_stop() 


### PR DESCRIPTION
grep with full-format listing can cause collisions with
other processes with java/daemon in their process args.