### PR TITLE
Split OTHER_ARGS into a bash array before feeding to java

### DIFF
--- a/templates/jenkins-slave-run.erb
+++ b/templates/jenkins-slave-run.erb
@@ -63,7 +63,12 @@ if [ -n "$TOOL_LOCATIONS" ]; then
   done
 fi
 
-[[ -n "$OTHER_ARGS" ]] &&
-  SLAVE_ARGS+=("$OTHER_ARGS")
+if [[ -n "$OTHER_ARGS" ]]; then
+  OIFS="$IFS"
+  IFS=' '
+  read -a MORE_ARGS <<< "${OTHER_ARGS}"
+  IFS="$OIFS"
+  SLAVE_ARGS+=("${MORE_ARGS[@]}")
+fi
 
 $JAVA "${SLAVE_ARGS[@]}"


### PR DESCRIPTION
If you have multiple args in OTHER_ARGS they will get joined together as
a string with spaces and then the entire string will be added to the
SLAVE_ARGS array as a single argument.  So if I have array ("a" "b" "c")
and then OTHER_ARGS has "d e f" then I get an array of ("a" "b" "c" "d e
f")

This doesn't work very well if you're passing multiple arguments in
OTHER_ARGS.  For instance I'm trying to pass two flags, one has a value
so when I set ["-flag1", "value1", "-flag2"] the value passed to flag1
is "value1 -flag2".

Splitting here on spaces is also a little naive, but it works in more
cases than the current setup.  In general argument parsing is kinda hard
and should probably have a little more thought around it to get it to
100%