### PR TITLE
Make CSP/Parameterization opt-in

### DIFF
--- a/templates/jenkins-run.erb
+++ b/templates/jenkins-run.erb
@@ -50,20 +50,28 @@ do
   JENKINS_JAVA_CMD="$candidate"
 done
 
-JAVA_CMD="$JENKINS_JAVA_CMD"
-
-# Split out all the java options on space.  Things that need spaces will need to have their own param
-# setup
-OIFS="$IFS"
-IFS=' '
-read -a JENKINS_JAVA_CMD_OPTIONS <<< "${JENKINS_JAVA_OPTIONS}"
-IFS="$OIFS"
+JAVA_CMD="$JENKINS_JAVA_CMD $JENKINS_JAVA_OPTIONS -DJENKINS_HOME=$JENKINS_HOME -jar $JENKINS_WAR"
 
 PARAMS=()
-PARAMS+=("${JENKINS_JAVA_CMD_OPTIONS[@]}")
-[ -n "$JENKINS_CSP_OPTIONS" ] && PARAMS+=("-Dhudson.model.DirectoryBrowserSupport.CSP=${JENKINS_CSP_OPTIONS}")
-PARAMS+=("-DJENKINS_HOME=$JENKINS_HOME")
-PARAMS+=("-jar" "$JENKINS_WAR")
+
+# Allow for opt-in on splitting out the java options to a param list
+# This is required to use many CSP options
+if [ -n "$JENKINS_JAVA_OPTIONS_TO_PARAMS" ]; then
+  JAVA_CMD="$JENKINS_JAVA_CMD"
+
+  # Split out all the java options on space.  Things that need spaces will need to have their own param
+  # setup
+  OIFS="$IFS"
+  IFS=' '
+  read -a JENKINS_JAVA_CMD_OPTIONS <<< "${JENKINS_JAVA_OPTIONS}"
+  IFS="$OIFS"
+
+  PARAMS+=("${JENKINS_JAVA_CMD_OPTIONS[@]}")
+  [ -n "$JENKINS_CSP_OPTIONS" ] && PARAMS+=("-Dhudson.model.DirectoryBrowserSupport.CSP=${JENKINS_CSP_OPTIONS}")
+  PARAMS+=("-DJENKINS_HOME=$JENKINS_HOME")
+  PARAMS+=("-jar" "$JENKINS_WAR")
+fi
+
 PARAMS+=("--logfile=/var/log/jenkins/jenkins.log")
 PARAMS+=("--webroot=/var/cache/jenkins/war")
 PARAMS+=("--daemon")


### PR DESCRIPTION
There can be situations where you do not want your java options split
up, and in fact this has probably been working for most people for a
while now, so make the param split-up with CSP options an opt-in aspect

This means to use CSP you'll need to specify split params as well as the
CSP options since you might split params without CSP, but it's unlikely
that you'll be able to do the reverse.